### PR TITLE
This seems to make sense at least with what I am seeing locally, sync the cookie expiration.

### DIFF
--- a/SecureSession.php
+++ b/SecureSession.php
@@ -110,7 +110,7 @@ class SecureSession {
             setcookie(
                 $this->_keyName,
                 base64_encode($this->_key) . ':' . base64_encode($this->_auth),
-                $cookie_param['lifetime'],
+                time() + $cookie_param['lifetime'],
                 $cookie_param['path'],
                 $cookie_param['domain'],
                 $cookie_param['secure'],


### PR DESCRIPTION
Cookie needs to be time + lifetime to coincide with session id cookie time.
