### PR TITLE
allow open() method to handle special session cookie lifetime value of 0

### DIFF
--- a/SecureSession.php
+++ b/SecureSession.php
@@ -110,7 +110,7 @@ class SecureSession {
             setcookie(
                 $this->_keyName,
                 base64_encode($this->_key) . ':' . base64_encode($this->_auth),
-                time() + $cookie_param['lifetime'],
+                ($cookie_param['lifetime'] > 0) ? time() + $cookie_param['lifetime'] : 0, // if session cookie lifetime > 0 then add to current time; otherwise leave it as zero, honoring zero's special meaning: expire at browser close.
                 $cookie_param['path'],
                 $cookie_param['domain'],
                 $cookie_param['secure'],


### PR DESCRIPTION
If the session cookie lifetime (session.cookie_lifetime) is zero, also set the cookie expiration time to zero, so that the special meaning of zero, "expire when browser closes," is preserved. (If this special meaning is not considered, the expiration time becomes time() + 0, or the current time, which causes the session to expire immediately.)
