### PR TITLE
Add setting  array COOKIE.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor
 clover.xml
 coveralls-upload.json
+nbproject

--- a/src/SecureHandler.php
+++ b/src/SecureHandler.php
@@ -157,6 +157,7 @@ class SecureHandler extends SessionHandler
                 $cookieParam['secure'],
                 $cookieParam['httponly']
             );
+            $_COOKIE[$name] = base64_encode($key);
         } else {
             $key = base64_decode($_COOKIE[$name]);
         }


### PR DESCRIPTION
 If we call session_start(), session_write_close() and re..session_start(), the cryption key is regenerate and causes an error during the first call